### PR TITLE
añadir editar perfil y recuperar contraseña

### DIFF
--- a/frontend/src/pages/MyProfile.css
+++ b/frontend/src/pages/MyProfile.css
@@ -31,11 +31,30 @@
   position: relative;
   display: flex;
   align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+}
+.perfil__hero-left {
+  display: flex;
+  align-items: center;
   gap: 22px;
 }
+.perfil__hero-actions { margin-left: auto; }
 
 /* Informacion del usuario */
 .perfil__hero-info { display: flex; flex-direction: column; gap: 8px; }
+
+/* Contenedor del formulario dentro del modal */
+.perfil__modal-form { display: flex; flex-direction: column; gap: 12px; }
+.perfil__modal-info { margin-top: 10px; font-size: 13px; color: var(--text2); display: flex; flex-direction: column; gap: 3px; border: 1px solid var(--border); background: var(--surface2); border-radius: 8px; padding: 10px; }
+.perfil__modal-alert { margin-top: 6px; }
+
+/* Ajustes responsive para hero */
+@media (max-width: 720px) {
+  .perfil__hero-content { flex-direction: column; align-items: flex-start; }
+  .perfil__hero-actions { margin-left: 0; width: 100%; }
+}
+
 
 /* Nombre del usuario */
 .perfil__nombre {

--- a/frontend/src/pages/MyProfile.jsx
+++ b/frontend/src/pages/MyProfile.jsx
@@ -1,8 +1,11 @@
-﻿import { useState, useEffect } from 'react';
-import { obtenerPerfilAPI } from '../services/api';
+﻿import { useState, useEffect, useContext } from 'react';
+import { obtenerPerfilAPI, actualizarPerfilAPI } from '../services/api';
+import { AuthContext } from '../context/AuthContext';
 import Avatar from '../components/ui/Avatar';
 import Badge  from '../components/ui/Badge';
 import Alert  from '../components/ui/Alert';
+import Modal  from '../components/ui/Modal';
+import Button from '../components/ui/Button';
 import './MyProfile.css';
 
 /* ── Icono de usuario ── */
@@ -52,11 +55,12 @@ function FilaPerfil({ icono, etiqueta, valor }) {
 
 /* ================================================================
    Pagina: Mi Perfil
-   Llama a GET /api/auth/profile para mostrar datos del usuario
-   autenticado. El backend no tiene endpoint de edicion de perfil,
-   por lo que solo se muestra la informacion.
+  Llama a GET /api/auth/profile para mostrar datos del usuario
+  autenticado y permite editar nombre y contrasena desde un modal.
    ================================================================ */
 export default function MyProfile() {
+  const { refrescarPerfil } = useContext(AuthContext);
+
   /* Datos del usuario cargados del backend */
   const [usuario, setUsuario] = useState(null);
   /* Estado de carga */
@@ -64,23 +68,73 @@ export default function MyProfile() {
   /* Error de carga */
   const [error, setError] = useState(null);
 
-  /* ── Carga del perfil desde el backend ── */
+  /* Estados para editar perfil */
+  const [modalAbierto, setModalAbierto] = useState(false);
+  const [nombreEdicion, setNombreEdicion] = useState('');
+  const [passwordEdicion, setPasswordEdicion] = useState('');
+  const [verPassword, setVerPassword] = useState(false);
+  const [guardando, setGuardando] = useState(false);
+  const [errorModal, setErrorModal] = useState('');
+  const [exito, setExito] = useState('');
+
+  const cargarPerfil = async () => {
+    setCargando(true);
+    setError(null);
+    try {
+      const data = await obtenerPerfilAPI();
+      setUsuario(data.user ?? null);
+    } catch (e) {
+      setError(e.message ?? 'Error al cargar el perfil');
+    } finally {
+      setCargando(false);
+    }
+  };
+
   useEffect(() => {
-    const cargar = async () => {
-      setCargando(true);
-      setError(null);
-      try {
-        const data = await obtenerPerfilAPI();
-        /* El backend devuelve { success, user: { id, name, email, role, createdAt } } */
-        setUsuario(data.user ?? null);
-      } catch (e) {
-        setError(e.message ?? 'Error al cargar el perfil');
-      } finally {
-        setCargando(false);
-      }
-    };
-    cargar();
+    cargarPerfil();
   }, []);
+
+  const abrirModalEdicion = () => {
+    setErrorModal('');
+    setExito('');
+    setNombreEdicion(usuario?.name ?? '');
+    setPasswordEdicion('');
+    setVerPassword(false);
+    setModalAbierto(true);
+  };
+
+  const cerrarModalEdicion = () => {
+    setModalAbierto(false);
+    setErrorModal('');
+    setGuardando(false);
+  };
+
+  const guardarPerfil = async () => {
+    setErrorModal('');
+    if (!nombreEdicion.trim()) {
+      setErrorModal('El nombre no puede estar vacío.');
+      return;
+    }
+
+    const datos = { name: nombreEdicion.trim() };
+    if (passwordEdicion.trim()) {
+      datos.password = passwordEdicion;
+    }
+
+    setGuardando(true);
+
+    try {
+      await actualizarPerfilAPI(datos);
+      await refrescarPerfil();
+      await cargarPerfil();
+      setModalAbierto(false);
+      setExito('Perfil actualizado correctamente.');
+    } catch (e) {
+      setErrorModal(e.message || 'Error al actualizar el perfil');
+    } finally {
+      setGuardando(false);
+    }
+  };
 
   /* ── Formateador de fecha en espanol ── */
   const fecha = iso => iso
@@ -114,6 +168,10 @@ export default function MyProfile() {
           <p className="page-header__desc">Informacion de tu cuenta en CorpHR</p>
         </div>
       </div>
+
+      {exito && (
+        <Alert tipo="success" onCerrar={() => setExito('')}>{exito}</Alert>
+      )}
 
       {/* ── Skeleton de carga ── */}
       {cargando && (
@@ -151,14 +209,21 @@ export default function MyProfile() {
             <div className="perfil__hero">
               <div className="perfil__hero-bg" />
               <div className="perfil__hero-content">
-                <Avatar texto={iniciales(usuario.name)} tamano="xl" />
-                <div className="perfil__hero-info">
-                  <h2 className="perfil__nombre">{usuario.name}</h2>
-                  <p className="perfil__email">{usuario.email}</p>
-                  <div className="perfil__badges">
-                    <Badge texto={etiquetaRol(usuario.role)} tipo={colorRol(usuario.role)} />
-                    <Badge texto="Cuenta activa" tipo="green" dot />
+                <div className="perfil__hero-left">
+                  <Avatar texto={iniciales(usuario.name)} tamano="xl" />
+                  <div className="perfil__hero-info">
+                    <h2 className="perfil__nombre">{usuario.name}</h2>
+                    <p className="perfil__email">{usuario.email}</p>
+                    <div className="perfil__badges">
+                      <Badge texto={etiquetaRol(usuario.role)} tipo={colorRol(usuario.role)} />
+                      <Badge texto="Cuenta activa" tipo="green" dot />
+                    </div>
                   </div>
+                </div>
+                <div className="perfil__hero-actions">
+                  <Button variante="secondary" onClick={abrirModalEdicion}>
+                    Editar perfil
+                  </Button>
                 </div>
               </div>
             </div>
@@ -191,11 +256,71 @@ export default function MyProfile() {
             </div>
           </div>
 
-          {/* Banner informativo: edicion no disponible */}
-          <Alert tipo="info" className="perfil__nota">
-            La edicion del perfil no esta disponible en esta version. Contacta al administrador para realizar cambios.
-          </Alert>
         </>
+      )}
+
+      {modalAbierto && usuario && (
+        <Modal
+          titulo="Editar perfil"
+          onClose={cerrarModalEdicion}
+          ancho="480px"
+          footer={(
+            <>
+              <Button variante="ghost" onClick={cerrarModalEdicion}>Cancelar</Button>
+              <Button variante="primary" onClick={guardarPerfil} cargando={guardando}>Guardar cambios</Button>
+            </>
+          )}
+        >
+          <div className="perfil__modal-form">
+            <div className="field">
+              <label htmlFor="perfil-nombre" className="field__label">Nombre completo</label>
+              <input
+                id="perfil-nombre"
+                type="text"
+                className="field__input"
+                value={nombreEdicion}
+                onChange={(e) => setNombreEdicion(e.target.value)}
+                autoComplete="name"
+              />
+            </div>
+
+            <div className="field">
+              <label htmlFor="perfil-password" className="field__label">Nueva contraseña</label>
+              <div className="field__input-wrap">
+                <input
+                  id="perfil-password"
+                  type={verPassword ? 'text' : 'password'}
+                  className="field__input"
+                  value={passwordEdicion}
+                  onChange={(e) => setPasswordEdicion(e.target.value)}
+                  autoComplete="new-password"
+                  placeholder="Dejar vacío para no cambiar"
+                />
+                <button
+                  type="button"
+                  className="field__eye"
+                  onClick={() => setVerPassword((v) => !v)}
+                  aria-label={verPassword ? 'Ocultar contraseña' : 'Mostrar contraseña'}
+                >
+                  {verPassword ? (
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round"><path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24"/><line x1="1" y1="1" x2="23" y2="23"/></svg>
+                  ) : (
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
+                  )}
+                </button>
+              </div>
+            </div>
+
+            <div className="perfil__modal-info">
+              <p><strong>Correo:</strong> {usuario.email}</p>
+              <p><strong>Rol:</strong> {etiquetaRol(usuario.role)}</p>
+            </div>
+
+            {errorModal && (
+              <Alert tipo="error" className="perfil__modal-alert">{errorModal}</Alert>
+            )}
+          </div>
+        </Modal>
       )}
     </div>
   );

--- a/frontend/src/pages/RecoverPassword.jsx
+++ b/frontend/src/pages/RecoverPassword.jsx
@@ -1,12 +1,11 @@
 ﻿/* ============================================================
    RecoverPassword.jsx — Pagina de recuperacion de contrasena
-   No hay endpoint en el backend para esta funcionalidad.
-   Se muestra un formulario visual con mensaje informativo.
    ============================================================ */
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
+import { recuperarContrasenaAPI } from '../services/api';
 import Button from '../components/ui/Button';
-import Alert  from '../components/ui/Alert';
+import Alert from '../components/ui/Alert';
 import './RecoverPassword.css';
 
 /* ── Icono de sobre ── */
@@ -26,29 +25,34 @@ const IcoArrowLeft = () => (
 );
 
 export default function RecoverPassword() {
-  /* Email ingresado por el usuario */
   const [email, setEmail] = useState('');
-  /* Estado de envio (simula carga) */
   const [enviando, setEnviando] = useState(false);
-  /* Mensaje de confirmacion (una vez enviado) */
   const [enviado, setEnviado] = useState(false);
+  const [error, setError] = useState('');
 
-  /* ── Manejo del envio del formulario ── */
-  const handleSubmit = async e => {
+  const handleSubmit = async (e) => {
     e.preventDefault();
     if (!email.trim()) return;
+
+    setError('');
     setEnviando(true);
 
-    /* Simulacion de envio (no hay endpoint en el backend) */
-    await new Promise(r => setTimeout(r, 1200));
-    setEnviando(false);
-    setEnviado(true);
+    try {
+      const respuesta = await recuperarContrasenaAPI(email.trim());
+      if (respuesta?.success) {
+        setEnviado(true);
+      } else {
+        throw new Error('No se pudo enviar la solicitud de recuperacion.');
+      }
+    } catch (err) {
+      setError(err.message || 'Error al enviar instrucciones de recuperacion.');
+    } finally {
+      setEnviando(false);
+    }
   };
 
   return (
     <div className="recover-page">
-
-      {/* ── Panel de branding (izquierdo) ── */}
       <div className="recover-brand">
         <div className="recover-brand__logo">
           <span className="recover-brand__dot" />
@@ -58,32 +62,25 @@ export default function RecoverPassword() {
           <h1 className="recover-brand__title">Recupera el acceso<br />a tu cuenta.</h1>
           <p className="recover-brand__sub">Te enviaremos instrucciones para restablecer tu contrasena de forma segura.</p>
         </div>
-        {/* Decoraciones de fondo */}
         <div className="recover-brand__circle recover-brand__circle--1" />
         <div className="recover-brand__circle recover-brand__circle--2" />
       </div>
 
-      {/* ── Panel del formulario (derecho) ── */}
       <div className="recover-form-panel">
         <div className="recover-form-wrap">
-
-          {/* Enlace de regreso al login */}
           <Link to="/login" className="recover-back">
             <IcoArrowLeft /> Volver al inicio de sesion
           </Link>
 
-          {/* Icono decorativo */}
           <div className="recover-icon">
             <IcoMail />
           </div>
 
-          {/* Titulo del formulario */}
           <h2 className="recover-title">Olvide mi contrasena</h2>
           <p className="recover-desc">
             Ingresa tu correo electronico y te enviaremos un enlace para restablecer tu contrasena.
           </p>
 
-          {/* Vista de confirmacion (despues de enviar) */}
           {enviado ? (
             <div className="recover-success">
               <div className="recover-success__icon">✅</div>
@@ -92,39 +89,38 @@ export default function RecoverPassword() {
                 Si <strong>{email}</strong> esta registrado, recibiras las instrucciones en breve.
                 Revisa tu carpeta de spam si no encuentras el correo.
               </p>
-              <Alert tipo="info" style={{ marginTop: 16 }}>
-                Esta funcionalidad aun no esta habilitada en el servidor. Contacta al administrador.
-              </Alert>
               <Link to="/login" className="recover-login-link">
                 Regresar al inicio de sesion
               </Link>
             </div>
           ) : (
-            /* Formulario de recuperacion */
-            <form className="recover-form" onSubmit={handleSubmit}>
-              <div className="field">
-                <label className="field__label" htmlFor="rec-email">Correo electronico</label>
-                <input
-                  id="rec-email"
-                  type="email"
-                  className="field__input"
-                  placeholder="tucorreo@empresa.com"
-                  value={email}
-                  onChange={e => setEmail(e.target.value)}
-                  required
-                  autoFocus
-                />
-              </div>
+            <>
+              {error && (
+                <Alert tipo="error" onCerrar={() => setError('')}>
+                  {error}
+                </Alert>
+              )}
 
-              <Button type="submit" variante="primary" fullWidth cargando={enviando}>
-                Enviar instrucciones
-              </Button>
+              <form className="recover-form" onSubmit={handleSubmit}>
+                <div className="field">
+                  <label className="field__label" htmlFor="rec-email">Correo electronico</label>
+                  <input
+                    id="rec-email"
+                    type="email"
+                    className="field__input"
+                    placeholder="tucorreo@empresa.com"
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
+                    required
+                    autoFocus
+                  />
+                </div>
 
-              {/* Aviso de funcionalidad sin backend */}
-              <Alert tipo="warning" className="recover-warn">
-                Esta funcion aun no tiene soporte en el servidor. Contacta al administrador del sistema.
-              </Alert>
-            </form>
+                <Button type="submit" variante="primary" fullWidth cargando={enviando}>
+                  Enviar instrucciones
+                </Button>
+              </form>
+            </>
           )}
         </div>
       </div>

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -117,6 +117,27 @@ export const logoutAPI = () =>
 export const obtenerPerfilAPI = () =>
   peticion('/auth/profile');
 
+/**
+ * Actualizar nombre y/o contraseña del usuario autenticado.
+ * @param {{ name?: string, password?: string }} datos
+ */
+export const actualizarPerfilAPI = (datos) =>
+  peticion('/auth/profile', {
+    method: 'PUT',
+    body: JSON.stringify(datos),
+  });
+
+/**
+ * Solicitar recuperacion de contrasena por email.
+ * El backend envia el correo con el enlace de restablecimiento.
+ * @param {string} email
+ */
+export const recuperarContrasenaAPI = (email) =>
+  peticion('/auth/recover', {
+    method: 'POST',
+    body: JSON.stringify({ email }),
+  });
+
 /* ============================================================
    DEPARTAMENTOS — mapeados al recurso /categories del backend
    Modelo: { _id, name, description, createdAt }


### PR DESCRIPTION
## Cambios
- Agrega edición de perfil desde `MyProfile` con modal reutilizando `Modal`
- Permite actualizar nombre y contraseña del usuario autenticado
- Agrega feedback de éxito y error en edición de perfil
- Reemplaza el flujo simulado de recuperación de contraseña por llamada real a API
- Elimina alertas placeholder temporales en recuperación
- Agrega funciones `actualizarPerfilAPI` y `recuperarContrasenaAPI` en `api.js`

## Validación
- `npm run build`

## Notas
- El frontend ya maneja los flujos completos
- Los endpoints `PUT /api/auth/profile` y `POST /api/auth/recover` aún dependen de implementación backend
- Mientras no existan, la UI mostrará los errores del servidor correctamente